### PR TITLE
getContext is the correct method.

### DIFF
--- a/sensors/ex2_boxes/ex2_boxes.pde
+++ b/sensors/ex2_boxes/ex2_boxes.pde
@@ -30,7 +30,7 @@ void setup() {
   fullScreen(P2D);
   orientation(PORTRAIT);
   
-  context = getActivity();
+  context = getContext();
   manager = (SensorManager)context.getSystemService(Context.SENSOR_SERVICE);
   sensor = manager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
   listener = new AccelerometerListener();


### PR DESCRIPTION
When using as a live wallpaper `getActivity()` crashes the app.